### PR TITLE
Add more waiting and retry to succeed in platform-ref-aws

### DIFF
--- a/functions/xflux/main.k
+++ b/functions/xflux/main.k
@@ -49,9 +49,9 @@ _items = [
                     imageAutomationController = { create = False }
                     imageReflectionController = { create = False }
                 }
-                # Resilience configurations to handle webhook race conditions
+                # Resilience configurations to handle webhook race conditions and rate limiting
                 wait = True               # Wait for resources to be ready
-                waitTimeout = "900s"      # 15 minute timeout to handle webhook delays
+                waitTimeout = "1800s"     # 30 minute timeout to handle webhook delays and rate limiting
             }
         }
     }
@@ -100,9 +100,9 @@ _items = [
                         }
                     }
                 }
-                # Resilience configurations to handle webhook race conditions
+                # Resilience configurations to handle webhook race conditions and rate limiting
                 wait = True               # Wait for resources to be ready
-                waitTimeout = "900s"      # 15 minute timeout to handle webhook delays
+                waitTimeout = "1800s"     # 30 minute timeout to handle webhook delays and rate limiting
             }
         }
     }

--- a/functions/xflux/main.k
+++ b/functions/xflux/main.k
@@ -37,6 +37,7 @@ _items = [
         spec = {
             providerConfigRef = { name = _providerConfigName }
             deletionPolicy = _deletionPolicy
+            rollbackLimit = 15            # More rollback attempts for resilience
             forProvider = {
                 chart = {
                     name = "flux2"
@@ -48,6 +49,9 @@ _items = [
                     imageAutomationController = { create = False }
                     imageReflectionController = { create = False }
                 }
+                # Resilience configurations to handle webhook race conditions
+                wait = True               # Wait for resources to be ready
+                waitTimeout = "900s"      # 15 minute timeout to handle webhook delays
             }
         }
     }
@@ -61,6 +65,7 @@ _items = [
         spec = {
             providerConfigRef = { name = _providerConfigName }
             deletionPolicy = _deletionPolicy
+            rollbackLimit = 15            # More rollback attempts for resilience
             forProvider = {
                 chart = {
                     name = "flux2-sync"
@@ -95,6 +100,9 @@ _items = [
                         }
                     }
                 }
+                # Resilience configurations to handle webhook race conditions
+                wait = True               # Wait for resources to be ready
+                waitTimeout = "900s"      # 15 minute timeout to handle webhook delays
             }
         }
     }

--- a/tests/e2etest-xflux/kcl.mod.lock
+++ b/tests/e2etest-xflux/kcl.mod.lock
@@ -3,3 +3,10 @@
     name = "model"
     full_name = "models_0.0.1"
     version = "0.0.1"
+    reg = "ghcr.io"
+    repo = "kcl-lang/model"
+    oci_tag = "0.0.1"
+  [dependencies.models]
+    name = "models"
+    full_name = "models_0.0.1"
+    version = "0.0.1"

--- a/tests/e2etest-xflux/main.k
+++ b/tests/e2etest-xflux/main.k
@@ -22,8 +22,8 @@ _items = [
                             providerConfigName = "uptest-gitops-flux-cluster"
                             deletionPolicy = "Delete"
                             operators = {
-                                flux = { version = "2.10.6" }
-                                fluxSync = { version = "1.7.2" }
+                                flux = { version = "2.16.4" }
+                                fluxSync = { version = "1.13.4" }
                             }
                             source = {
                                 git = {
@@ -43,7 +43,7 @@ _items = [
                     apiVersion: "pkg.crossplane.io/v1"
                     kind: "Configuration"
                     metadata.name: "configuration-aws-eks"
-                    spec.package: "xpkg.upbound.io/upbound/configuration-aws-eks:v0.18.2"
+                    spec.package: "xpkg.upbound.io/upbound/configuration-aws-eks:v0.19.0"
                 }
                 {
                     apiVersion: "pkg.crossplane.io/v1"
@@ -112,7 +112,7 @@ _items = [
                                 instanceType = "t3.small"
                             }
                             region = "us-west-1"
-                            version = "1.29"
+                            version = "1.33"
                         }
                         writeConnectionSecretToRef = {
                             name = "configuration-gitops-flux-kubeconfig"


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

During the test with platform-ref-aws that also installs aws-lb-controller, flux release was failing with

```
Status:
  At Provider:
    Release Description:  Release "release-flux" failed: 3 errors occurred:
                          * Internal error occurred: failed calling webhook "mservice.elbv2.k8s.aws": failed to call webhook: Post "https://aws-load-balancer-webhook-service.kube-system.svc:443/mutate-v1-service?timeout=10s": no endpoints available for service "aws-load-balancer-webhook-service"
                          * Internal error occurred: failed calling webhook "mservice.elbv2.k8s.aws": failed to call webhook: Post "https://aws-load-balancer-webhook-service.kube-system.svc:443/mutate-v1-service?timeout=10s": no endpoints available for service "aws-load-balancer-webhook-service"
                          * Internal error occurred: failed calling webhook "mservice.elbv2.k8s.aws": failed to call webhook: Post "https://aws-load-balancer-webhook-service.kube-system.svc:443/mutate-v1-service?timeout=10s": no endpoints available for service "aws-load-balancer-webhook-service"
```

racing with aws-lb-controller pods to be started.

More waiting time and retries fix the situation. Same for deletion.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

* Composition Tests
```
up test run tests/*
  ✓   Parsing tests
  ✓   Collecting resources
  ✓   Generating language schemas
  ✓   Checking dependencies
  ✓   Building functions
  ✓   Building configuration package
  ✓   Pushing embedded functions to local daemon
  ✓   Assert test-xcluster
SUCCESS:
SUCCESS: Tests Summary:
SUCCESS: ------------------
SUCCESS: Total Tests Executed: 1
SUCCESS: Passed tests:         1
SUCCESS: Failed tests:         0
```

* e2e tests(pipeline below)

* Acceptance tests with higher level platform-ref-aws 
```
crossplane beta trace cluster.aws.platformref.upbound.io/platform-ref-aws
NAME                                                                               SYNCED   READY   STATUS
Cluster/platform-ref-aws (default)                                                 True     True    Available
└─ XCluster/platform-ref-aws-dnmcj                                                 True     True    Available
   ├─ Usage/platform-ref-aws-eks-by-flux                                           -        True    Available
   ├─ Usage/platform-ref-aws-eks-by-labeled-release                                -        -
   ├─ Usage/platform-ref-aws-eks-by-oss                                            -        True    Available
   ├─ Usage/platform-ref-aws-lb-controller-by-flux                                 -        True    Available
   ├─ Usage/platform-ref-aws-lb-controller-by-labeled-app                          -        -
   ├─ Usage/platform-ref-aws-network-by-eks                                        -        True    Available
   ├─ XAWSLBController/platform-ref-aws-lb-controller                              True     True    Available
   │  ├─ Usage/usage-xeks-by-awslbcontroller                                       -        True    Available
   │  ├─ XPodIdentity/podidentity                                                  True     True    Available
   │  │  ├─ PodIdentityAssociation/platform-ref-aws-dnmcj-t444l                    True     True    Available
   │  │  └─ Role/platform-ref-aws-dnmcj-crlpp                                      True     True    Available
   │  └─ Release/helmrelease                                                       True     True    Available
   ├─ XEKS/platform-ref-aws-eks                                                    True     True    Available
   │  ├─ SecurityGroup/platform-ref-aws-dnmcj-zb74n                                True     True    Available
   │  ├─ Addon/platform-ref-aws-dnmcj-6tcz2                                        True     True    Available
   │  ├─ Addon/platform-ref-aws-dnmcj-vkdk2                                        True     True    Available
   │  ├─ Addon/platform-ref-aws-dnmcj-vqx2m                                        True     True    Available
   │  ├─ ClusterAuth/platform-ref-aws-dnmcj-pfm7s                                  True     True    Available
   │  ├─ Cluster/platform-ref-aws-dnmcj-4wj6h                                      True     True    Available
   │  ├─ NodeGroup/platform-ref-aws-dnmcj-lcnhc                                    True     True    Available
   │  ├─ ProviderConfig/platform-ref-aws                                           -        -
   │  ├─ Role/platform-ref-aws-dnmcj-8g66n                                         True     True    Available
   │  ├─ Role/platform-ref-aws-dnmcj-qn8ml                                         True     True    Available
   │  └─ ProviderConfig/platform-ref-aws                                           -        -
   ├─ XNetwork/platform-ref-aws-network                                            True     True    Available
   │  ├─ InternetGateway/platform-ref-aws-dnmcj-bsq88                              True     True    Available
   │  ├─ MainRouteTableAssociation/platform-ref-aws-dnmcj-krw2c                    True     True    Available
   │  ├─ RouteTableAssociation/platform-ref-aws-dnmcj-9ltt2                        True     True    Available
   │  ├─ RouteTableAssociation/platform-ref-aws-dnmcj-jzpgq                        True     True    Available
   │  ├─ RouteTableAssociation/platform-ref-aws-dnmcj-ljzbj                        True     True    Available
   │  ├─ RouteTableAssociation/platform-ref-aws-dnmcj-plvwv                        True     True    Available
   │  ├─ RouteTable/platform-ref-aws-dnmcj-5xlzg                                   True     True    Available
   │  ├─ SecurityGroupRule/platform-ref-aws-dnmcj-jk2xz                            True     True    Available
   │  ├─ SecurityGroupRule/platform-ref-aws-dnmcj-kltmk                            True     True    Available
   │  ├─ SecurityGroup/platform-ref-aws-dnmcj-pfmbt                                True     True    Available
   │  ├─ Subnet/platform-ref-aws-dnmcj-9v8p5                                       True     True    Available
   │  ├─ Subnet/platform-ref-aws-dnmcj-jg66m                                       True     True    Available
   │  ├─ Subnet/platform-ref-aws-dnmcj-lqws8                                       True     True    Available
   │  ├─ Subnet/platform-ref-aws-dnmcj-vc2wx                                       True     True    Available
   │  ├─ VPC/platform-ref-aws-dnmcj-l2tlm                                          True     True    Available
   │  └─ Route/platform-ref-aws-dnmcj-86dq9                                        True     True    Available
   ├─ XFlux/platform-ref-aws-flux                                                  True     True    Available
   │  ├─ Release/release-flux                                                      True     True    Available
   │  └─ Release/sync-flux                                                         True     True    Available
   └─ XOss/platform-ref-aws-oss                                                    True     True    Available
      ├─ Usage/usageprometheusbypodmonitorcrossplane-platform-ref-aws              -        True    Available
      ├─ Usage/usageprometheusbypodmonitorcrossplanerbacmanager-platform-ref-aws   -        True    Available
      ├─ Usage/usageprometheusbypodmonitorproviders-platform-ref-aws               -        True    Available
      ├─ Release/releaseprometheus-platform-ref-aws                                True     True    Available
      ├─ Object/podmonitorcrossplane-platform-ref-aws                              True     True    Available
      ├─ Object/podmonitorcrossplaneproviders-platform-ref-aws                     True     True    Available
      └─ Object/podmonitorcrossplanerbacmanager-platform-ref-aws                   True     True    Available
```
